### PR TITLE
Merging changes to validation_forward 

### DIFF
--- a/miso/models/__init__.py
+++ b/miso/models/__init__.py
@@ -1,0 +1,1 @@
+from .decomp_transformer_syntax_parser import DecompTransformerSyntaxParser

--- a/miso/modules/seq2seq_encoders/__init__.py
+++ b/miso/modules/seq2seq_encoders/__init__.py
@@ -7,6 +7,7 @@ from allennlp.modules.encoder_base import RnnStateStorage
 from miso.modules.stacked_bilstm import MisoStackedBidirectionalLstm
 
 from .seq2seq_bert_encoder import Seq2SeqBertEncoder, BaseBertWrapper
+from .transformer_encoder import MisoTransformerEncoder
 
 
 class _PytorchSeq2SeqWrapper(PytorchSeq2SeqWrapper):

--- a/miso/training/decomp_parsing_trainer.py
+++ b/miso/training/decomp_parsing_trainer.py
@@ -99,6 +99,9 @@ class DecompTrainer(Trainer):
         assert len(batch_group) == 1
         batch = batch_group[0]
         batch = nn_util.move_to_device(batch, self._cuda_devices[0])
+
+        # before running forward, set oracle to True
+        self.model.oracle = True
         output_dict = self.model(**batch)
 
         return output_dict
@@ -153,6 +156,9 @@ class DecompTrainer(Trainer):
             val_true_instances.append(batch_group)
 
             batch_output = self._validation_forward(batch_group)
+            # TODO (Jimena): make sure that there are no other errors relating to the fact that the 
+            # batch_output is now from self.model._training_forward and not self.model._test_forward
+
             loss = batch_output.pop("loss", None)
             if loss is not None:
                 # You shouldn't necessarily have to compute a loss for validation, so we allow for
@@ -164,6 +170,7 @@ class DecompTrainer(Trainer):
                 val_loss += loss.detach().cpu().numpy()
 
             # Update the description with the latest metrics
+            # TODO (Jimena): this line might be a problem 
             val_metrics = training_util.get_metrics(self.model, val_loss, batches_this_epoch)
             description = training_util.description_from_metrics(val_metrics)
             val_generator_tqdm.set_description(description, refresh=False)
@@ -172,6 +179,7 @@ class DecompTrainer(Trainer):
             peek = list(batch_output.values())[0]
             batch_size = peek.size(0) if isinstance(peek, torch.Tensor) else len(peek)
             instance_separated_output: List[Dict[str, numpy.ndarray]] = [{} for _ in range(batch_size)]
+            # TODO (Jimena): these lines might also raise errors
             for name, value in batch_output.items():
                 if isinstance(value, torch.Tensor):
                     # NOTE(markn): This is a hack because 0-dim pytorch tensors are not iterable.
@@ -187,7 +195,10 @@ class DecompTrainer(Trainer):
         # Now restore the original parameter values.
         if self._moving_average is not None:
             self._moving_average.restore()
-        self._update_validation_s_score(val_outputs, val_true_instances)
+
+        # turn off s score if we're in pearson-only mode
+        if not self.model.oracle: 
+            self._update_validation_s_score(val_outputs, val_true_instances)
 
         if hasattr(self, "_update_validation_syntax_score"):
             self._update_validation_syntax_score(val_outputs, val_true_instances)


### PR DESCRIPTION
validation forward now has self.model.oracle=True, making it go to training_forward instead of test_forward